### PR TITLE
enhancement: add validation for variables and support for resolver query logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_logging_configuration"></a> [cloudwatch\_logging\_configuration](#input\_cloudwatch\_logging\_configuration) | Cloudwatch logs configuration | <pre>object({<br/>    kms_key_arn       = string<br/>    log_group_name    = optional(string, "/platform/route53/resolver-query-logs")<br/>    retention_in_days = optional(number, 90)<br/>  })</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | n/a | yes |
-| <a name="input_cloudwatch_logging_configuration"></a> [cloudwatch\_logging\_configuration](#input\_cloudwatch\_logging\_configuration) | Cloudwatch logs configuration | <pre>object({<br/>    kms_key_arn       = string<br/>    log_group_name    = optional(string, "/platform/route53/resolver-query-logs")<br/>    retention_in_days = optional(number, 90)<br/>    vpc_id            = string<br/>  })</pre> | `null` | no |
 | <a name="input_direction"></a> [direction](#input\_direction) | The resolver endpoint flow direction | `string` | `"INBOUND"` | no |
 | <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | A list of IP addresses and subnets where Route53 resolver endpoints will be deployed | <pre>list(object({<br/>    ip        = optional(string)<br/>    subnet_id = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | <pre>[<br/>  "Do53",<br/>  "DoH"<br/>]</pre> | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Route53 Resolver Endpoint Security Group, allows port 53 for DNS resolving | `string` | `null` | no |
 | <a name="input_security_group_egress_cidr_blocks"></a> [security\_group\_egress\_cidr\_blocks](#input\_security\_group\_egress\_cidr\_blocks) | A list of CIDR blocks to allow on security group egress rules | `list(string)` | `[]` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs | `list(string)` | `[]` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs, if not specified a default security group will be created | `list(string)` | `[]` | no |
 | <a name="input_security_group_ingress_cidr_blocks"></a> [security\_group\_ingress\_cidr\_blocks](#input\_security\_group\_ingress\_cidr\_blocks) | A list of CIDR blocks to allow on security group ingress rules | `list(string)` | `[]` | no |
-| <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | The prefix of the security group | `string` | `null` | no |
+| <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | The prefix of the security group | `string` | `"route53-resolver-"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnets where Route53 resolver endpoints will be deployed | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags for the Route53 resolver endpoint | `map(string)` | `{}` | no |
 | <a name="input_type"></a> [type](#input\_type) | The resolver endpoint IP type | `string` | `"IPV4"` | no |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.resolver_query_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_route53_resolver_endpoint.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_endpoint) | resource |
+| [aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config) | resource |
+| [aws_route53_resolver_query_log_config_association.resolver_query_config_cloudwatch_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config_association) | resource |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
@@ -36,13 +39,14 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | n/a | yes |
-| <a name="input_security_group_egress_cidr_blocks"></a> [security\_group\_egress\_cidr\_blocks](#input\_security\_group\_egress\_cidr\_blocks) | A list of CIDR blocks to allow on security group egress rules | `list(string)` | n/a | yes |
-| <a name="input_security_group_ingress_cidr_blocks"></a> [security\_group\_ingress\_cidr\_blocks](#input\_security\_group\_ingress\_cidr\_blocks) | A list of CIDR blocks to allow on security group ingress rules | `list(string)` | n/a | yes |
+| <a name="input_cloudwatch_logging_configuration"></a> [cloudwatch\_logging\_configuration](#input\_cloudwatch\_logging\_configuration) | Cloudwatch logs configuration | <pre>object({<br/>    kms_key_arn       = string<br/>    log_group_name    = optional(string, "/platform/route53/resolver-query-logs")<br/>    retention_in_days = optional(number, 90)<br/>    vpc_id            = string<br/>  })</pre> | `null` | no |
 | <a name="input_direction"></a> [direction](#input\_direction) | The resolver endpoint flow direction | `string` | `"INBOUND"` | no |
 | <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | A list of IP addresses and subnets where Route53 resolver endpoints will be deployed | <pre>list(object({<br/>    ip        = optional(string)<br/>    subnet_id = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_protocols"></a> [protocols](#input\_protocols) | The resolver endpoint protocols | `list(string)` | <pre>[<br/>  "Do53",<br/>  "DoH"<br/>]</pre> | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Route53 Resolver Endpoint Security Group, allows port 53 for DNS resolving | `string` | `null` | no |
+| <a name="input_security_group_egress_cidr_blocks"></a> [security\_group\_egress\_cidr\_blocks](#input\_security\_group\_egress\_cidr\_blocks) | A list of CIDR blocks to allow on security group egress rules | `list(string)` | `[]` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs | `list(string)` | `[]` | no |
+| <a name="input_security_group_ingress_cidr_blocks"></a> [security\_group\_ingress\_cidr\_blocks](#input\_security\_group\_ingress\_cidr\_blocks) | A list of CIDR blocks to allow on security group ingress rules | `list(string)` | `[]` | no |
 | <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | The prefix of the security group | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnets where Route53 resolver endpoints will be deployed | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags for the Route53 resolver endpoint | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  security_group_ids = var.security_group_name_prefix != null ? [module.security_group[0].id] : var.security_group_ids
+  security_group_ids = length(var.security_group_ids) == 0 ? [module.security_group[0].id] : var.security_group_ids
   subnet_ids         = [for subnet in var.subnet_ids : { subnet_id = subnet }]
 }
 
@@ -26,7 +26,7 @@ data "aws_subnet" "selected" {
 }
 
 module "security_group" {
-  count = var.security_group_name_prefix != null ? 1 : 0
+  count = length(var.security_group_ids) == 0 ? 1 : 0
 
   source  = "schubergphilis/mcaf-security-group/aws"
   version = "~> 2.0.0"
@@ -76,5 +76,5 @@ resource "aws_route53_resolver_query_log_config_association" "resolver_query_con
   count = var.cloudwatch_logging_configuration != null ? 1 : 0
 
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch[0].id
-  resource_id                  = var.cloudwatch_logging_configuration.vpc_id
+  resource_id                  = data.aws_subnet.selected.vpc_id
 }

--- a/main.tf
+++ b/main.tf
@@ -56,3 +56,25 @@ module "security_group" {
     }
   }
 }
+
+resource "aws_cloudwatch_log_group" "resolver_query_logs" {
+  count = var.cloudwatch_logging_configuration != null ? 1 : 0
+
+  name              = var.cloudwatch_logging_configuration.log_group_name
+  kms_key_id        = var.cloudwatch_logging_configuration.kms_key_arn
+  retention_in_days = var.cloudwatch_logging_configuration.retention_in_days
+}
+
+resource "aws_route53_resolver_query_log_config" "resolver_query_log_config_cloudwatch" {
+  count = var.cloudwatch_logging_configuration != null ? 1 : 0
+
+  name            = "resolver_query_log_config_cloudwatch"
+  destination_arn = aws_cloudwatch_log_group.resolver_query_logs[0].arn
+}
+
+resource "aws_route53_resolver_query_log_config_association" "resolver_query_config_cloudwatch_association" {
+  count = var.cloudwatch_logging_configuration != null ? 1 : 0
+
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch[0].id
+  resource_id                  = var.cloudwatch_logging_configuration.vpc_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,7 @@ variable "cloudwatch_logging_configuration" {
     kms_key_arn       = string
     log_group_name    = optional(string, "/platform/route53/resolver-query-logs")
     retention_in_days = optional(number, 90)
-    vpc_id            = string
   })
-  default     = null
   description = "Cloudwatch logs configuration"
 }
 
@@ -48,23 +46,18 @@ variable "security_group_egress_cidr_blocks" {
 
   validation {
     condition = !(
-      var.security_group_name_prefix != null &&
+      length(var.security_group_ids) == 0 &&
       var.direction == "OUTBOUND" &&
       length(var.security_group_egress_cidr_blocks) == 0
     )
-    error_message = "'security_group_egress_cidr_blocks' must be set when 'security_group_name_prefix' is set and 'direction' is set to 'OUTBOUND'"
+    error_message = "'security_group_egress_cidr_blocks' must be set when 'security_group_ids' is not set and 'direction' is set to 'OUTBOUND'"
   }
 }
 
 variable "security_group_ids" {
   type        = list(string)
   default     = []
-  description = "A list of security group IDs"
-
-  validation {
-    condition     = length(var.security_group_ids) > 0 || var.security_group_name_prefix != null
-    error_message = "Either 'security_group_ids' or 'security_group_name_prefix' must be set"
-  }
+  description = "A list of security group IDs, if not specified a default security group will be created"
 }
 
 variable "security_group_ingress_cidr_blocks" {
@@ -74,17 +67,17 @@ variable "security_group_ingress_cidr_blocks" {
 
   validation {
     condition = !(
-      var.security_group_name_prefix != null &&
+      length(var.security_group_ids) == 0 &&
       var.direction == "INBOUND" &&
       length(var.security_group_ingress_cidr_blocks) == 0
     )
-    error_message = "'security_group_ingress_cidr_blocks' must be set when 'security_group_name_prefix' is set and 'direction' is set to 'INBOUND'"
+    error_message = "'security_group_ingress_cidr_blocks' must be set when 'security_group_ids' is not set and 'direction' is set to 'INBOUND'"
   }
 }
 
 variable "security_group_name_prefix" {
   type        = string
-  default     = null
+  default     = "route53-resolver-"
   description = "The prefix of the security group"
 }
 


### PR DESCRIPTION
**:hammer_and_wrench: Summary**

- Added defaults and validation on the variables
    - Validation to check if either var.security_group_name_prefix or var.security_group_ids is set
    - Made var.security_group_ingress_cidr_blocks mandatory only when var.security_group_name_prefix is set and var.direction is set to 'INBOUND'
    - Made var.security_group_egress_cidr_blocks mandatory only when var.security_group_name_prefix is set and var.direction is set to 'OUTBOUND'

- Added support for delivering resolver query logs to cloudwatch logs
