### PR TITLE
breaking: Resolver rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,13 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.resolver_query_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_route53_resolver_endpoint.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_endpoint) | resource |
-| [aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config) | resource |
-| [aws_route53_resolver_query_log_config_association.resolver_query_config_cloudwatch_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config_association) | resource |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cloudwatch_logging_configuration"></a> [cloudwatch\_logging\_configuration](#input\_cloudwatch\_logging\_configuration) | Cloudwatch logs configuration | <pre>object({<br/>    kms_key_arn       = string<br/>    log_group_name    = optional(string, "/platform/route53/resolver-query-logs")<br/>    retention_in_days = optional(number, 90)<br/>  })</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The resolver endpoint name | `string` | n/a | yes |
 | <a name="input_direction"></a> [direction](#input\_direction) | The resolver endpoint flow direction | `string` | `"INBOUND"` | no |
 | <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | A list of IP addresses and subnets where Route53 resolver endpoints will be deployed | <pre>list(object({<br/>    ip        = optional(string)<br/>    subnet_id = string<br/>  }))</pre> | `[]` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,8 @@ This document captures required refactoring on your part when upgrading to a mod
 
 #### Variables
 
+The following variables have been added as part of sub modules:
+
 Submodule: resolver-rules
 
 `resolver_endpoint_id`: The ID of the Route 53 resolver endpoint.
@@ -19,7 +21,7 @@ Submodule: resolver-rules
 `target_ips`: List of IP addresses for the target IPs.
 
 Submodule: resolver-logging
-`cloudwatch_logging_configuration`: Cloudwatch logs configuration, including KMS key ARN, optional log group name (default /platform/route53/resolver-query-logs), and optional retention in days (default 90).
+`cloudwatch_logging_configuration`: Cloudwatch logs configuration, including KMS key ARN.
 `vpc_id`: The ID of the VPC where the resolver endpoint will be created and logging will be associated.
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,58 @@
 # Upgrading Notes
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v2.0.0
+
+### Key Changes
+
+- CloudWatch log configuration has now moved out of the root module and included in the submodule that a user can call it seperately.
+- Introducing a submodule to create resolver rules directly from this module.
+
+#### Variables
+
+Submodule: resolver-rules
+
+`resolver_endpoint_id`: The ID of the Route 53 resolver endpoint.
+`resolver_rules`: Map of resolver rule definitions.
+`rule_type`: The rule type for the resolver rule (usually FORWARD). Default value is FORWARD.
+`target_ips`: List of IP addresses for the target IPs.
+
+Submodule: resolver-logging
+`cloudwatch_logging_configuration`: Cloudwatch logs configuration, including KMS key ARN, optional log group name (default /platform/route53/resolver-query-logs), and optional retention in days (default 90).
+`vpc_id`: The ID of the VPC where the resolver endpoint will be created and logging will be associated.
+
+
+### How to upgrade v5.0.0
+
+The Cloudwatch log resources has been moved to a seperate submodule.
+you can call the module for creating the cloudwatch log and move your existing resources.
+
+
+
+if you already have the resolver rule created and you would like to move them to the module then ensure that you move your resources to the module.
+
+```hcl
+moved {
+  from = module.outbound_resolver_endpoints.aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch
+  to   = module.route53_resolver_logging.aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch[0]
+}
+
+moved {
+  from = module.outbound_resolver_endpoints.aws_route53_resolver_query_log_config_association.resolver_query_config_cloudwatch_association
+  to   = module.route53_resolver_logging.aws_route53_resolver_query_log_config_association.resolver_query_config_cloudwatch_association[0]
+}
+
+moved {
+  from = module.outbound_resolver_endpoints.aws_cloudwatch_log_group.resolver_query_logs
+  to   = module.route53_resolver_logging.aws_cloudwatch_log_group.resolver_query_logs[0]
+}
+```
+
+
+```hcl
+moved {
+  from = aws_route53_resolver_rule.outbound_forwarding_rule["outbound-example"]
+  to   = module.route53_resolver_rule.aws_route53_resolver_rule.resolver_rules["outbound-example"]
+}
+```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,3 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,14 +25,11 @@ Submodule: resolver-logging
 `vpc_id`: The ID of the VPC where the resolver endpoint will be created and logging will be associated.
 
 
-### How to upgrade v5.0.0
+### How to upgrade v2.0.0
 
 The Cloudwatch log resources has been moved to a seperate submodule.
 you can call the module for creating the cloudwatch log and move your existing resources.
 
-
-
-if you already have the resolver rule created and you would like to move them to the module then ensure that you move your resources to the module.
 
 ```hcl
 moved {
@@ -51,6 +48,7 @@ moved {
 }
 ```
 
+if you already have the resolver rule created and you would like to move them to the module then ensure that you move your resources to the module.
 
 ```hcl
 moved {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,6 +2,16 @@ provider "aws" {
   region = "eu-west-1"
 }
 
+# kms
+module "kms_key" {
+  source  = "schubergphilis/mcaf-kms/aws"
+  version = "~> 0.3.0"
+
+  name        = "kmstest"
+  description = "KMS key used for encrypting all resources in the account"
+  policy      = data.aws_iam_policy_document.kms_key_policy.json
+}
+
 # vpc
 module "vpc" {
   source  = "schubergphilis/mcaf-vpc/aws"
@@ -40,4 +50,30 @@ module "outbound_resolver_endpoints" {
   security_group_ingress_cidr_blocks = [module.vpc.cidr_block]
   security_group_name_prefix         = "resolver-endpoints-example-"
   subnet_ids                         = module.vpc.private_subnet_ids
+}
+
+# Example to create the Route53 Outbound Resolver rules
+module "route53_resolver_rule" {
+  source = "../../modules/resolver-rules"
+
+  resolver_endpoint_id = module.outbound_resolver_endpoints.route53_resolver_endpoint_id
+  resolver_rules = {
+    "outbound-m-adds-p1" = "m-adds-p-1.example.nl"
+    "outbound-m-adds-p2" = "m-adds-p-2.example.nl"
+  }
+  target_ips = [
+    "10.1.1.1",
+    "10.1.1.2"
+  ]
+}
+
+# Example to create the Route53 Outbound Resolver Cloudwatch log
+module "route53_resolver_logging" {
+  source = "../../modules/resolver-logging"
+
+  cloudwatch_logging_configuration = {
+    kms_key_arn    = module.kms_key.arn
+    log_group_name = "/ep/route53/resolver-query-logs"
+  }
+  vpc_id = module.vpc.id
 }

--- a/main.tf
+++ b/main.tf
@@ -56,25 +56,3 @@ module "security_group" {
     }
   }
 }
-
-resource "aws_cloudwatch_log_group" "resolver_query_logs" {
-  count = var.cloudwatch_logging_configuration != null ? 1 : 0
-
-  name              = var.cloudwatch_logging_configuration.log_group_name
-  kms_key_id        = var.cloudwatch_logging_configuration.kms_key_arn
-  retention_in_days = var.cloudwatch_logging_configuration.retention_in_days
-}
-
-resource "aws_route53_resolver_query_log_config" "resolver_query_log_config_cloudwatch" {
-  count = var.cloudwatch_logging_configuration != null ? 1 : 0
-
-  name            = "resolver_query_log_config_cloudwatch"
-  destination_arn = aws_cloudwatch_log_group.resolver_query_logs[0].arn
-}
-
-resource "aws_route53_resolver_query_log_config_association" "resolver_query_config_cloudwatch_association" {
-  count = var.cloudwatch_logging_configuration != null ? 1 : 0
-
-  resolver_query_log_config_id = aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch[0].id
-  resource_id                  = data.aws_subnet.selected.vpc_id
-}

--- a/modules/resolver-logging/README.md
+++ b/modules/resolver-logging/README.md
@@ -10,14 +10,14 @@ IMPORTANT: We do not pin module versions in our examples. We highly recommend th
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 5.32 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
 
 ## Modules
 
@@ -35,9 +35,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cloudwatch_logging_configuration"></a> [cloudwatch_logging_configuration](#input_cloudwatch_logging_configuration) | CloudWatch logs configuration. | <pre>object({<br/>  kms_key_arn       = string<br/>  log_group_name    = optional(string, "/platform/route53/resolver-query-logs")<br/>  retention_in_days = optional(number, 90)<br/>})</pre> | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id) | The ID of the VPC where the resolver endpoint logging will be associated. | `string` | n/a | yes |
+| <a name="input_cloudwatch_logging_configuration"></a> [cloudwatch\_logging\_configuration](#input\_cloudwatch\_logging\_configuration) | Cloudwatch logs configuration | <pre>object({<br/>    kms_key_arn       = string<br/>    log_group_name    = optional(string, "/platform/route53/resolver-query-logs")<br/>    retention_in_days = optional(number, 90)<br/>  })</pre> | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC where the resolver endpoint will be created and logging will be associated | `string` | n/a | yes |
 
+## Outputs
+
+No outputs.
 <!-- END_TF_DOCS -->
 
 ## Licensing

--- a/modules/resolver-logging/README.md
+++ b/modules/resolver-logging/README.md
@@ -1,0 +1,46 @@
+# terraform-aws-mcaf-route53-resolver-logging
+
+Terraform submodule to enable **CloudWatch logging** for a Route53 Resolver endpoint.  
+This creates the CloudWatch log group, query log configuration, and associates it with a VPC.
+
+IMPORTANT: We do not pin module versions in our examples. We highly recommend that in your code you pin the version to the exact version you are using so that your infrastructure remains stable.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 5.32 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.32 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.resolver_query_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config) | resource |
+| [aws_route53_resolver_query_log_config_association.resolver_query_config_cloudwatch_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_query_log_config_association) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cloudwatch_logging_configuration"></a> [cloudwatch_logging_configuration](#input_cloudwatch_logging_configuration) | CloudWatch logs configuration. | <pre>object({<br/>  kms_key_arn       = string<br/>  log_group_name    = optional(string, "/platform/route53/resolver-query-logs")<br/>  retention_in_days = optional(number, 90)<br/>})</pre> | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id) | The ID of the VPC where the resolver endpoint logging will be associated. | `string` | n/a | yes |
+
+<!-- END_TF_DOCS -->
+
+## Licensing
+
+100% Open Source and licensed under the Apache License Version 2.0.  
+See [LICENSE](https://github.com/schubergphilis/terraform-aws-mcaf-route53-resolver/blob/master/LICENSE) for full details.

--- a/modules/resolver-logging/main.tf
+++ b/modules/resolver-logging/main.tf
@@ -1,0 +1,21 @@
+resource "aws_cloudwatch_log_group" "resolver_query_logs" {
+  count = var.cloudwatch_logging_configuration != null ? 1 : 0
+
+  name              = var.cloudwatch_logging_configuration.log_group_name
+  kms_key_id        = var.cloudwatch_logging_configuration.kms_key_arn
+  retention_in_days = var.cloudwatch_logging_configuration.retention_in_days
+}
+
+resource "aws_route53_resolver_query_log_config" "resolver_query_log_config_cloudwatch" {
+  count = var.cloudwatch_logging_configuration != null ? 1 : 0
+
+  name            = "resolver_query_log_config_cloudwatch"
+  destination_arn = aws_cloudwatch_log_group.resolver_query_logs[0].arn
+}
+
+resource "aws_route53_resolver_query_log_config_association" "resolver_query_config_cloudwatch_association" {
+  count = var.cloudwatch_logging_configuration != null ? 1 : 0
+
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.resolver_query_log_config_cloudwatch[0].id
+  resource_id                  = var.vpc_id
+}

--- a/modules/resolver-logging/terraform.tf
+++ b/modules/resolver-logging/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.32"
+    }
+  }
+}

--- a/modules/resolver-logging/variables.tf
+++ b/modules/resolver-logging/variables.tf
@@ -1,0 +1,13 @@
+variable "cloudwatch_logging_configuration" {
+  type = object({
+    kms_key_arn       = string
+    log_group_name    = optional(string, "/platform/route53/resolver-query-logs")
+    retention_in_days = optional(number, 90)
+  })
+  description = "Cloudwatch logs configuration"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC where the resolver endpoint will be created and logging will be associated"
+}

--- a/modules/resolver-rules/README.md
+++ b/modules/resolver-rules/README.md
@@ -33,9 +33,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_name_prefix"></a> [name_prefix](#input_name_prefix) | Prefix to use for resolver rule names. | `string` | `"outbound-"` | no |
 | <a name="input_resolver_endpoint_id"></a> [resolver_endpoint_id](#input_resolver_endpoint_id) | The ID of the Route 53 resolver endpoint. | `string` | n/a | yes |
-| <a name="input_resolver_rules"></a> [resolver_rules](#input_resolver_rules) | List of resolver rule domain names to create rules for. | `list(string)` | n/a | yes |
+| <a name="input_resolver_rules"></a> [resolver_rules](#input_resolver_rules) | Map of resolver rule domain names to create rules for. | `map(string)` | n/a | yes |
 | <a name="input_rule_type"></a> [rule_type](#input_rule_type) | The rule type for the resolver rule (usually FORWARD). | `string` | `"FORWARD"` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | Tags to apply to the resolver rules. | `map(string)` | `{}` | no |
 | <a name="input_target_ips"></a> [target_ips](#input_target_ips) | List of IP addresses for the target IPs. | `list(string)` | n/a | yes |

--- a/modules/resolver-rules/README.md
+++ b/modules/resolver-rules/README.md
@@ -10,14 +10,14 @@ IMPORTANT: We do not pin module versions in our examples. We highly recommend th
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 5.32 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.32 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
 
 ## Modules
 
@@ -33,19 +33,18 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_resolver_endpoint_id"></a> [resolver_endpoint_id](#input_resolver_endpoint_id) | The ID of the Route 53 resolver endpoint. | `string` | n/a | yes |
-| <a name="input_resolver_rules"></a> [resolver_rules](#input_resolver_rules) | Map of resolver rule domain names to create rules for. | `map(string)` | n/a | yes |
-| <a name="input_rule_type"></a> [rule_type](#input_rule_type) | The rule type for the resolver rule (usually FORWARD). | `string` | `"FORWARD"` | no |
-| <a name="input_tags"></a> [tags](#input_tags) | Tags to apply to the resolver rules. | `map(string)` | `{}` | no |
-| <a name="input_target_ips"></a> [target_ips](#input_target_ips) | List of IP addresses for the target IPs. | `list(string)` | n/a | yes |
+| <a name="input_resolver_endpoint_id"></a> [resolver\_endpoint\_id](#input\_resolver\_endpoint\_id) | The ID of the Route 53 resolver endpoint. | `string` | n/a | yes |
+| <a name="input_resolver_rules"></a> [resolver\_rules](#input\_resolver\_rules) | Map of resolver rule definitions | `map(string)` | n/a | yes |
+| <a name="input_target_ips"></a> [target\_ips](#input\_target\_ips) | List of IP addresses for the target IPs. | `list(string)` | n/a | yes |
+| <a name="input_rule_type"></a> [rule\_type](#input\_rule\_type) | The rule type for the resolver rule (usually FORWARD). | `string` | `"FORWARD"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resolver rules. | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_resolver_rule_ids"></a> [resolver_rule_ids](#output_resolver_rule_ids) | Map of resolver rule IDs, keyed by domain name. |
-| <a name="output_resolver_rule_arns"></a> [resolver_rule_arns](#output_resolver_rule_arns) | Map of resolver rule ARNs, keyed by domain name. |
-
+| <a name="output_resolver_rule_arns"></a> [resolver\_rule\_arns](#output\_resolver\_rule\_arns) | Map of resolver rule arns. |
+| <a name="output_resolver_rule_ids"></a> [resolver\_rule\_ids](#output\_resolver\_rule\_ids) | Map of resolver rule IDs. |
 <!-- END_TF_DOCS -->
 
 ## Licensing

--- a/modules/resolver-rules/README.md
+++ b/modules/resolver-rules/README.md
@@ -1,0 +1,55 @@
+# terraform-aws-mcaf-route53-resolver-rules
+
+Terraform submodule to create Route53 Resolver rules.  
+This module creates resolver rules for forwarding DNS queries using specified target IPs.
+
+IMPORTANT: We do not pin module versions in our examples. We highly recommend that in your code you pin the version to the exact version you are using so that your infrastructure remains stable.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | >= 5.32 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.32 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_resolver_rule.resolver_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name_prefix"></a> [name_prefix](#input_name_prefix) | Prefix to use for resolver rule names. | `string` | `"outbound-"` | no |
+| <a name="input_resolver_endpoint_id"></a> [resolver_endpoint_id](#input_resolver_endpoint_id) | The ID of the Route 53 resolver endpoint. | `string` | n/a | yes |
+| <a name="input_resolver_rules"></a> [resolver_rules](#input_resolver_rules) | List of resolver rule domain names to create rules for. | `list(string)` | n/a | yes |
+| <a name="input_rule_type"></a> [rule_type](#input_rule_type) | The rule type for the resolver rule (usually FORWARD). | `string` | `"FORWARD"` | no |
+| <a name="input_tags"></a> [tags](#input_tags) | Tags to apply to the resolver rules. | `map(string)` | `{}` | no |
+| <a name="input_target_ips"></a> [target_ips](#input_target_ips) | List of IP addresses for the target IPs. | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_resolver_rule_ids"></a> [resolver_rule_ids](#output_resolver_rule_ids) | Map of resolver rule IDs, keyed by domain name. |
+| <a name="output_resolver_rule_arns"></a> [resolver_rule_arns](#output_resolver_rule_arns) | Map of resolver rule ARNs, keyed by domain name. |
+
+<!-- END_TF_DOCS -->
+
+## Licensing
+
+100% Open Source and licensed under the Apache License Version 2.0.  
+See [LICENSE](https://github.com/schubergphilis/terraform-aws-mcaf-route53-resolver/blob/master/LICENSE) for full details.

--- a/modules/resolver-rules/main.tf
+++ b/modules/resolver-rules/main.tf
@@ -2,7 +2,7 @@ resource "aws_route53_resolver_rule" "resolver_rules" {
   for_each = toset(var.resolver_rules)
 
   domain_name          = each.value
-  name                 = "${var.name_prefix}${each.value}"
+  name                 = replace("${var.name_prefix}${each.value}", ".", "-")
   rule_type            = var.rule_type
   resolver_endpoint_id = var.resolver_endpoint_id
   tags                 = var.tags

--- a/modules/resolver-rules/main.tf
+++ b/modules/resolver-rules/main.tf
@@ -1,0 +1,16 @@
+resource "aws_route53_resolver_rule" "resolver_rules" {
+  for_each = toset(var.resolver_rules)
+
+  domain_name          = each.value
+  name                 = "${var.name_prefix}${each.value}"
+  rule_type            = var.rule_type
+  resolver_endpoint_id = var.resolver_endpoint_id
+  tags                 = var.tags
+
+  dynamic "target_ip" {
+    for_each = var.target_ips
+    content {
+      ip = target_ip.value
+    }
+  }
+}

--- a/modules/resolver-rules/main.tf
+++ b/modules/resolver-rules/main.tf
@@ -2,7 +2,7 @@ resource "aws_route53_resolver_rule" "resolver_rules" {
   for_each = toset(var.resolver_rules)
 
   domain_name          = each.value
-  name                 = replace("${var.name_prefix}${each.value}", ".", "-")
+  name                 = each.key
   rule_type            = var.rule_type
   resolver_endpoint_id = var.resolver_endpoint_id
   tags                 = var.tags

--- a/modules/resolver-rules/main.tf
+++ b/modules/resolver-rules/main.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_resolver_rule" "resolver_rules" {
-  for_each = toset(var.resolver_rules)
+  for_each = var.resolver_rules
 
   domain_name          = each.value
   name                 = each.key

--- a/modules/resolver-rules/outputs.tf
+++ b/modules/resolver-rules/outputs.tf
@@ -1,0 +1,15 @@
+output "resolver_rule_ids" {
+  description = "Map of resolver rule IDs."
+  value = {
+    for k, rule in aws_route53_resolver_rule.resolver_rules :
+    k => rule.id
+  }
+}
+
+output "resolver_rule_arns" {
+  description = "Map of resolver rule arns."
+  value = {
+    for k, rule in aws_route53_resolver_rule.resolver_rules :
+    k => rule.arn
+  }
+}

--- a/modules/resolver-rules/terraform.tf
+++ b/modules/resolver-rules/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.32"
+    }
+  }
+}

--- a/modules/resolver-rules/variables.tf
+++ b/modules/resolver-rules/variables.tf
@@ -5,7 +5,7 @@ variable "resolver_endpoint_id" {
 
 variable "resolver_rules" {
   type        = map(string)
-  description = "Map of resolver rule definitions, keyed by domain."
+  description = "Map of resolver rule definitions"
 }
 
 variable "rule_type" {

--- a/modules/resolver-rules/variables.tf
+++ b/modules/resolver-rules/variables.tf
@@ -1,0 +1,31 @@
+variable "name_prefix" {
+  type    = string
+  default = "outbound-"
+}
+
+variable "resolver_endpoint_id" {
+  type        = string
+  description = "The ID of the Route 53 resolver endpoint."
+}
+
+variable "resolver_rules" {
+  type        = list(string)
+  description = "Map of resolver rule definitions, keyed by domain."
+}
+
+variable "rule_type" {
+  type        = string
+  default     = "FORWARD"
+  description = "The rule type for the resolver rule (usually FORWARD)."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to the resolver rules."
+}
+
+variable "target_ips" {
+  type        = list(string)
+  description = "List of IP addresses for the target IPs."
+}

--- a/modules/resolver-rules/variables.tf
+++ b/modules/resolver-rules/variables.tf
@@ -1,15 +1,10 @@
-variable "name_prefix" {
-  type    = string
-  default = "outbound"
-}
-
 variable "resolver_endpoint_id" {
   type        = string
   description = "The ID of the Route 53 resolver endpoint."
 }
 
 variable "resolver_rules" {
-  type        = list(string)
+  type        = map(string)
   description = "Map of resolver rule definitions, keyed by domain."
 }
 

--- a/modules/resolver-rules/variables.tf
+++ b/modules/resolver-rules/variables.tf
@@ -1,6 +1,6 @@
 variable "name_prefix" {
   type    = string
-  default = "outbound-"
+  default = "outbound"
 }
 
 variable "resolver_endpoint_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,3 @@
-variable "cloudwatch_logging_configuration" {
-  type = object({
-    kms_key_arn       = string
-    log_group_name    = optional(string, "/platform/route53/resolver-query-logs")
-    retention_in_days = optional(number, 90)
-  })
-  description = "Cloudwatch logs configuration"
-}
-
 variable "direction" {
   type        = string
   default     = "INBOUND"


### PR DESCRIPTION
## :hammer_and_wrench: Summary

- Create a submodule for cloudwatch log for resolver. 
- Create a submodule for Resolver rules.

## :rocket: Motivation

- This fix resolves the issue where the CloudWatch log configuration was created every time the module was invoked, ensuring it is now created only once per VPC.
- This will enable users to deploy resolver rules directly from this module.

## :pencil: Additional Information


