### PR TITLE
enhancement: add feature for resolver rule association

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -97,15 +97,18 @@ module "outbound_resolver_endpoints" {
   subnet_ids                         = module.vpc.private_subnet_ids
 }
 
-# Example to create the Route53 Outbound Resolver rules
+# Example to create the Route53 Outbound Resolver rules and associate them with the vpc
 module "route53_resolver_rule" {
   source = "../../modules/resolver-rules"
 
   resolver_endpoint_id = module.outbound_resolver_endpoints.route53_resolver_endpoint_id
+  vpc_id               = module.vpc.id
+
   resolver_rules = {
     "outbound-m-adds-p1" = "m-adds-p-1.example.nl"
     "outbound-m-adds-p2" = "m-adds-p-2.example.nl"
   }
+
   target_ips = [
     "10.1.1.1",
     "10.1.1.2"

--- a/modules/resolver-rules/README.md
+++ b/modules/resolver-rules/README.md
@@ -28,6 +28,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_route53_resolver_rule.resolver_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule) | resource |
+| [aws_route53_resolver_rule_association.rule_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_rule_association) | resource |
 
 ## Inputs
 
@@ -38,6 +39,7 @@ No modules.
 | <a name="input_target_ips"></a> [target\_ips](#input\_target\_ips) | List of IP addresses for the target IPs. | `list(string)` | n/a | yes |
 | <a name="input_rule_type"></a> [rule\_type](#input\_rule\_type) | The rule type for the resolver rule (usually FORWARD). | `string` | `"FORWARD"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resolver rules. | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the Route53 Resolver rules should be associated | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/resolver-rules/main.tf
+++ b/modules/resolver-rules/main.tf
@@ -14,3 +14,10 @@ resource "aws_route53_resolver_rule" "resolver_rules" {
     }
   }
 }
+
+resource "aws_route53_resolver_rule_association" "rule_association" {
+  for_each = var.vpc_id != null ? var.resolver_rules : {}
+
+  resolver_rule_id = aws_route53_resolver_rule.resolver_rules[each.key].id
+  vpc_id           = var.vpc_id
+}

--- a/modules/resolver-rules/variables.tf
+++ b/modules/resolver-rules/variables.tf
@@ -24,3 +24,9 @@ variable "target_ips" {
   type        = list(string)
   description = "List of IP addresses for the target IPs."
 }
+
+variable "vpc_id" {
+  description = "VPC ID where the Route53 Resolver rules should be associated"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This pull request adds support for associating Route53 Resolver rules with a specific VPC in the `resolver-rules` Terraform module. The main changes introduce a new variable for specifying the VPC ID and create the necessary resource to handle the association.

**Support for VPC association:**

* Added a new variable `vpc_id` to allow users to specify the VPC where Route53 Resolver rules should be associated. (`modules/resolver-rules/variables.tf`)
* Introduced a new resource `aws_route53_resolver_rule_association` that associates each resolver rule with the specified VPC when `vpc_id` is provided. (`modules/resolver-rules/main.tf`)